### PR TITLE
VELOCITY.js Float as Argument

### DIFF
--- a/src/main/resources/Executor/VELOCITY.js
+++ b/src/main/resources/Executor/VELOCITY.js
@@ -17,13 +17,13 @@
 function VELOCITY(args){
 	if(player === null)
 		return null;
-	
+		
 	if(args.length != 3)
 		throw new Error("Invalid parameters! [Number, Number, Number]");
-	
-	args.forEach(function (value, i) {
-		if (typeof value == "string") {args[i] = parseFloat(value);}
-	});
+		
+	for (var i in [0, 1, 2]) {
+		if (typeof args[i] == "string") {args[i] = parseFloat(args[i]);}
+	}
 	
 	var Vector = Java.type('org.bukkit.util.Vector');
 	player.setVelocity(new Vector(args[0].doubleValue(), args[1].doubleValue(), args[2].doubleValue()));

--- a/src/main/resources/Executor/VELOCITY.js
+++ b/src/main/resources/Executor/VELOCITY.js
@@ -20,14 +20,13 @@ function VELOCITY(args){
 	
 	if(args.length != 3)
 		throw new Error("Invalid parameters! [Number, Number, Number]");
-		
-	if(typeof args[0] !== "number"
-		|| typeof args[1] !== "number"
-		|| typeof args[2] !== "number")
-		throw new Error("Invalid parameters! [Number, Number, Number]");
+	
+	args.forEach(function (value, i) {
+		if (typeof value == "string") {args[i] = parseFloat(value);}
+	});
 	
 	var Vector = Java.type('org.bukkit.util.Vector');
-	player.setVelocity(new Vector(args[0], args[1], args[2]));
+	player.setVelocity(new Vector(args[0].doubleValue(), args[1].doubleValue(), args[2].doubleValue()));
 
 	return null;
 }


### PR DESCRIPTION
적어도 인게임 챗에서는 /trg run #VELOCITY 0 0.1 0 과 같은 커맨드를 쓰면 에러를 출력하기에, "." 이 들어가 있는 인자는 스트링으로 취급한다는 걸 깨닫고 parseFloat을 추가 해 봤습니다.

만약 소수점 이외의 스트링을 써도 캐치가 안된다는 흠이 있지만, 일단 꽤나 치명적인 버그 같기에 PR남깁니다. 피드백 주시면 고치겠습니다.