### PR TITLE
 트리거 제거/편집 관련 Lore 기능

### DIFF
--- a/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
+++ b/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
@@ -18,12 +18,16 @@ package io.github.wysohn.triggerreactor.bukkit.main;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import io.github.wysohn.triggerreactor.bukkit.bridge.BukkitCommandSender;
@@ -68,6 +72,44 @@ public class TriggerReactor extends JavaPlugin {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if(sender instanceof Player){
+        	if(args.length >= 1){
+        		if(args[0].equalsIgnoreCase("tooledit")){
+        			if(sender.hasPermission("triggerreactor.admin")){
+        		           Player target = ((Player) sender).getPlayer();
+                       	
+        		            ItemStack Item = new ItemStack(Material.BONE, 1);
+        		            ItemMeta itemMeta = Item.getItemMeta();
+        		            itemMeta.setDisplayName("§a§l트리거 편집 도구");                  
+        		            itemMeta.setLore(Arrays.asList("§a트리거 편집 전용", "§finspection tool"));
+        		  
+        		            Item.setItemMeta(itemMeta);
+        		            target.getInventory().addItem(new ItemStack[]{Item});
+        		          
+        		            ItemStack Item1 = new ItemStack(Material.SHEARS, 1);
+        		            ItemMeta itemMeta1 = Item1.getItemMeta();
+        		            itemMeta1.setDisplayName("§a§l트리거 편집 도구");                  
+        		            itemMeta1.setLore(Arrays.asList("§a트리거 편집 전용", "§fcut tool"));
+        		   
+        		            Item1.setItemMeta(itemMeta1);        		           
+        		            target.getInventory().addItem(new ItemStack[]{Item1});
+        		                      
+                            ItemStack Item11 = new ItemStack(Material.PAPER, 1);
+        		            ItemMeta itemMeta11 = Item11.getItemMeta();
+        		            itemMeta11.setDisplayName("§a§l트리거 편집 도구");                  
+        		            itemMeta11.setLore(Arrays.asList("§a트리거 편집 전용", "§fcopy tool"));
+        		    
+        		            Item11.setItemMeta(itemMeta11);
+        		            target.getInventory().addItem(new ItemStack[]{Item11});
+        		            sender.sendMessage("§a트리거 편집 도구 지급완료!");
+        		        return true;
+        				
+        				
+        			}
+        			sender.sendMessage("§c[Trigger Reactor] 권한이 없습니다.");
+        			return false;
+        		}
+        			
+        	}
             return this.javaPluginBridge.onCommand(
                     new BukkitPlayer((Player) sender),
                     command.getName(),

--- a/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
+++ b/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/TriggerReactor.java
@@ -80,7 +80,7 @@ public class TriggerReactor extends JavaPlugin {
         		            ItemStack Item = new ItemStack(Material.BONE, 1);
         		            ItemMeta itemMeta = Item.getItemMeta();
         		            itemMeta.setDisplayName("§a§l트리거 편집 도구");                  
-        		            itemMeta.setLore(Arrays.asList("§a트리거 편집 전용", "§finspection tool"));
+        		            itemMeta.setLore(Arrays.asList("§c§r§a트리거 편집 전용", "§c§r§finspection tool"));
         		  
         		            Item.setItemMeta(itemMeta);
         		            target.getInventory().addItem(new ItemStack[]{Item});
@@ -88,7 +88,7 @@ public class TriggerReactor extends JavaPlugin {
         		            ItemStack Item1 = new ItemStack(Material.SHEARS, 1);
         		            ItemMeta itemMeta1 = Item1.getItemMeta();
         		            itemMeta1.setDisplayName("§a§l트리거 편집 도구");                  
-        		            itemMeta1.setLore(Arrays.asList("§a트리거 편집 전용", "§fcut tool"));
+        		            itemMeta1.setLore(Arrays.asList("§c§r§a트리거 편집 전용", "§c§r§fcut tool"));
         		   
         		            Item1.setItemMeta(itemMeta1);        		           
         		            target.getInventory().addItem(new ItemStack[]{Item1});
@@ -96,7 +96,7 @@ public class TriggerReactor extends JavaPlugin {
                             ItemStack Item11 = new ItemStack(Material.PAPER, 1);
         		            ItemMeta itemMeta11 = Item11.getItemMeta();
         		            itemMeta11.setDisplayName("§a§l트리거 편집 도구");                  
-        		            itemMeta11.setLore(Arrays.asList("§a트리거 편집 전용", "§fcopy tool"));
+        		            itemMeta11.setLore(Arrays.asList("§c§r§a트리거 편집 전용", "§c§r§fcopy tool"));
         		    
         		            Item11.setItemMeta(itemMeta11);
         		            target.getInventory().addItem(new ItemStack[]{Item11});

--- a/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/LocationBasedTriggerManager.java
+++ b/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/LocationBasedTriggerManager.java
@@ -82,8 +82,8 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
             		
             		if(!(IS.getItemMeta().getLore().isEmpty())){
           
-            			if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용") && IS.getItemMeta().
-            		getLore().get(1).contains("inspection tool")){
+            			if(IS.getItemMeta().getLore().get(0).equalsIgnoreCase("§c§r§a트리거 편집 전용") && IS.getItemMeta().
+            		getLore().get(1).contains("§c§r§finspection tool")){
                
                     removeTriggerForLocation(clicked.getLocation());
 
@@ -94,8 +94,8 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                 }else if(trigger != null && e.getAction() == Action.RIGHT_CLICK_BLOCK){
                 	if(!(IS.getItemMeta().getLore().isEmpty())){
                 		
-            			if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용") && IS.getItemMeta().
-            		getLore().get(1).contains("inspection tool")){               
+            			if(IS.getItemMeta().getLore().get(0).equalsIgnoreCase("§c§r§a트리거 편집 전용") && IS.getItemMeta().
+            		getLore().get(1).equalsIgnoreCase("§c§r§finspection tool")){               
                     if(e.getPlayer().isSneaking()){
                         handleScriptEdit(player, trigger);
                         e.setCancelled(true);
@@ -110,8 +110,8 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                
              	if(!(IS.getItemMeta().getLore().isEmpty())){            	
             	
-             		if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용")  && IS.getItemMeta().
-             				getLore().get(1).contains("Cut tool")  ){
+             		if(IS.getItemMeta().getLore().get(0).equalsIgnoreCase("§c§r§a트리거 편집 전용")  && IS.getItemMeta().
+             				getLore().get(1).equalsIgnoreCase("§c§r§fCut tool")  ){
             
                  
                     } if(e.getAction() == Action.LEFT_CLICK_BLOCK){
@@ -130,8 +130,8 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                 }
             }else if(IS.getType() == COPY_TOOL && (IS.hasItemMeta()) ){         
              
-            	if(player.getItemInHand().getItemMeta().getLore().get(0).equalsIgnoreCase("§a트리거 편집 전용")  &&
-            				IS.getItemMeta().getLore().get(1).equalsIgnoreCase("§fcopy tool")){
+            	if(player.getItemInHand().getItemMeta().getLore().get(0).equalsIgnoreCase("§c§r§a트리거 편집 전용")  &&
+            				IS.getItemMeta().getLore().get(1).equalsIgnoreCase("§c§r§fcopy tool")){
             	if(e.getAction() == Action.LEFT_CLICK_BLOCK){
                     if(pasteTrigger(player, clicked.getLocation())){
                         player.sendMessage(ChatColor.GREEN+"Successfully pasted the trigger!");

--- a/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/LocationBasedTriggerManager.java
+++ b/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/LocationBasedTriggerManager.java
@@ -57,7 +57,7 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
     public LocationBasedTriggerManager(TriggerReactor plugin, String folderName) {
         super(plugin, new CommonFunctions(plugin), new File(plugin.getDataFolder(), folderName));
     }
-
+ 
     @SuppressWarnings("deprecation")
     @EventHandler(priority = EventPriority.LOWEST)
     public void onClick(PlayerInteractEvent e){
@@ -77,13 +77,25 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                 &&!e.isCancelled()
                 && player.hasPermission("triggerreactor.admin")){
 
-            if(IS.getType() == INSPECTION_TOOL){
-                if(trigger != null && e.getAction() == Action.LEFT_CLICK_BLOCK){
+            if(IS.getType() == INSPECTION_TOOL && (IS.hasItemMeta())){
+            	if(trigger != null && e.getAction() == Action.LEFT_CLICK_BLOCK){
+            		
+            		if(!(IS.getItemMeta().getLore().isEmpty())){
+          
+            			if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용") && IS.getItemMeta().
+            		getLore().get(1).contains("inspection tool")){
+               
                     removeTriggerForLocation(clicked.getLocation());
 
                     player.sendMessage(ChatColor.GREEN+"A trigger has deleted.");
                     e.setCancelled(true);
+            			}
+            		}
                 }else if(trigger != null && e.getAction() == Action.RIGHT_CLICK_BLOCK){
+                	if(!(IS.getItemMeta().getLore().isEmpty())){
+                		
+            			if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용") && IS.getItemMeta().
+            		getLore().get(1).contains("inspection tool")){               
                     if(e.getPlayer().isSneaking()){
                         handleScriptEdit(player, trigger);
                         e.setCancelled(true);
@@ -91,28 +103,42 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                         this.showTriggerInfo(new BukkitPlayer(player), clicked);
                         e.setCancelled(true);
                     }
-                }
-            }else if(IS.getType() == CUT_TOOL){
-                if(e.getAction() == Action.LEFT_CLICK_BLOCK){
-                    if(pasteTrigger(player, clicked.getLocation())){
-                        player.sendMessage(ChatColor.GREEN+"Successfully pasted the trigger!");
-                        this.showTriggerInfo(new BukkitPlayer(player), clicked);
-                        e.setCancelled(true);
                     }
+            			}
+                }
+            }else if(IS.getType() == CUT_TOOL && (IS.hasItemMeta()) ){
+               
+             	if(!(IS.getItemMeta().getLore().isEmpty())){            	
+            	
+             		if(IS.getItemMeta().getLore().get(0).contains("트리거 편집 전용")  && IS.getItemMeta().
+             				getLore().get(1).contains("Cut tool")  ){
+            
+                 
+                    } if(e.getAction() == Action.LEFT_CLICK_BLOCK){
+                    	   if(pasteTrigger(player, clicked.getLocation())){
+                               player.sendMessage(ChatColor.GREEN+"Successfully pasted the trigger!");
+                               this.showTriggerInfo(new BukkitPlayer(player), clicked);
+                               e.setCancelled(true);
+            	}
                 }else if(trigger != null && e.getAction() == Action.RIGHT_CLICK_BLOCK){
                     if(cutTrigger(player, clicked.getLocation())){
                         player.sendMessage(ChatColor.GREEN+"Cut Complete!");
                         player.sendMessage(ChatColor.GREEN+"Now you can paste it by left click on any block!");
                         e.setCancelled(true);
                     }
+            	}
                 }
-            }else if(IS.getType() == COPY_TOOL){
-                if(e.getAction() == Action.LEFT_CLICK_BLOCK){
+            }else if(IS.getType() == COPY_TOOL && (IS.hasItemMeta()) ){         
+             
+            	if(player.getItemInHand().getItemMeta().getLore().get(0).equalsIgnoreCase("§a트리거 편집 전용")  &&
+            				IS.getItemMeta().getLore().get(1).equalsIgnoreCase("§fcopy tool")){
+            	if(e.getAction() == Action.LEFT_CLICK_BLOCK){
                     if(pasteTrigger(player, clicked.getLocation())){
                         player.sendMessage(ChatColor.GREEN+"Successfully pasted the trigger!");
                         this.showTriggerInfo(new BukkitPlayer(player), clicked);
                         e.setCancelled(true);
                     }
+           
                 }else if(e.getAction() == Action.RIGHT_CLICK_BLOCK){
                     if(trigger != null && copyTrigger(player, clicked.getLocation())){
                         player.sendMessage(ChatColor.GREEN+"Copy Complete!");
@@ -120,7 +146,9 @@ public abstract class LocationBasedTriggerManager<T extends Trigger> extends Abs
                         e.setCancelled(true);
                     }
                 }
+            		}
             }
+    
         }
 
         if(!e.isCancelled() && isLocationSetting(new BukkitPlayer(player))){

--- a/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactor.java
+++ b/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactor.java
@@ -18,6 +18,7 @@ package io.github.wysohn.triggerreactor.core.main;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.logging.Logger;
+
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.wysohn.triggerreactor.core.bridge.ICommandSender;
 import io.github.wysohn.triggerreactor.core.bridge.IInventory;
@@ -1016,6 +1023,9 @@ public abstract class TriggerReactor {
 
                     sender.sendMessage("Reload Complete!");
                     return true;
+                    
+                    
+                        
                 } else if (args[0].equalsIgnoreCase("help")) {
                     int page = 0;
                     if(args.length > 1) {
@@ -1342,6 +1352,9 @@ public abstract class TriggerReactor {
             sender.sendMessage("&b/triggerreactor[trg] saveall &8- &7Save all scripts, variables, and settings.");
 
             sender.sendMessage("&b/triggerreactor[trg] reload &8- &7Reload all scripts, variables, and settings.");
+            sender.sendMessage("&b/triggerreactor[trg] tooledit &8- &7트리거 편집 도구 지급.");
+
+
         });
     }};
 


### PR DESCRIPTION
 트리거 제거/편집 관련 Lore 기능
트리거 편집도구인 뼈다귀,가위,종이 클릭시 무조건 권한만 있으면 수정기능이 작동되던
것이 /trg tooledit 명령어로 수정용 도구 지급 및 해당 도구로만 수정이 되도록 변경(실수로 트리거를 삭제하거나 복사하는 행위 예방)