### PR TITLE
 Edited $packlist placeholder

### DIFF
--- a/src/main/resources/Placeholder/Bukkit/packlist.js
+++ b/src/main/resources/Placeholder/Bukkit/packlist.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *     Copyright (C) 2018 wysohn
+ *     Copyright (C) 2018 wysohn (idea provided by gerzytet, author Pro_Snape)
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
@@ -14,11 +14,78 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
- function packlist(args){
-    if(args.length < 2){
-        throw new Error("Array should have at least 2 arguments");
-    }
-    if(args.length >= 2){
-        return args;
-    }
+function isDouble(n){
+	return Number(n) === n && n % 1 !== 0;
+}
+function packlist(args){
+	if(args.length < 1){
+		throw new Error("$packlist placeholder should have at least 1 arguments!");
+	}
+	var arrType = args[0];
+	if(args.length == 1){
+		var arr = Array();
+		if(typeof arrType !== "string"){
+			throw new Error("Unknown Type '"+arrType+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+		}
+		if(arrType.toLowerCase() !== "string" && arrType.toLowerCase() !== "int"&& arrType.toLowerCase() !== "double") {
+			throw new Error("Unknown Type '"+arrType+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+		}else {	
+			if(arrType.toLowerCase() == "string") {
+				return Java.to(arr,"java.lang.String[]");
+			}
+			if(arrType.toLowerCase() == "int") {
+				return Java.to(arr,"int[]");
+			}
+			if(arrType.toLowerCase() == "double") {
+				return Java.to(arr,"java.lang.Double[]");
+			}	
+		}
+	}
+	if(args.length == 2){
+		var arr = Array()
+		arr.push(args[1]);
+	}
+	if(args.length > 2){
+		var arr = Array.apply(0, Array(args.length - 1));
+		for(i=1; i <= args.length - 1; i++) {
+			arr[i-1] = args[i];
+		}
+	}
+	if(arrType.toLowerCase() !== "string" && arrType.toLowerCase() !== "int"&& arrType.toLowerCase() !== "double") {
+		throw new Error("Unknown Type '"+args[0]+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+	}else {	
+		if(arrType.toLowerCase() == "string") {
+			var arrsType = "string";
+			var arrType = "java.lang.String";
+			var msgType = "String"
+		}
+		if(arrType.toLowerCase() == "int") {
+			var arrsType = "number";
+			var arrType = "java.lang.Integer";
+			var checkDouble = true;
+			var msgType = "Integer";
+		}
+		if(arrType.toLowerCase() == "double") {
+			var arrsType = "number";
+			var arrType = "java.lang.Double";
+			var checkInt = true;
+			var msgType = "Double";
+		}
+		for(i=0; i <= arr.length - 1; i++){
+			if(typeof arr[i] !== arrsType) {
+				throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+			}
+			if(checkDouble == true) {
+				if(isDouble(arr[i]) == true) {
+					throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+				}
+			}
+			if(checkInt == true) {
+				if(isDouble(arr[i]) !== true) {
+					throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+				}
+			}
+		}
+		return Java.to(arr, arrType+"[]")
+	}
 }

--- a/src/main/resources/Placeholder/Sponge/packlist.js
+++ b/src/main/resources/Placeholder/Sponge/packlist.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *     Copyright (C) 2018 wysohn
+ *     Copyright (C) 2018 wysohn (idea provided by gerzytet, author Pro_Snape)
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
@@ -14,11 +14,78 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *******************************************************************************/
- function packlist(args){
-    if(args.length < 2){
-        throw new Error("Array should have at least 2 arguments");
-    }
-    if(args.length >= 2){
-        return args;
-    }
+function isDouble(n){
+	return Number(n) === n && n % 1 !== 0;
+}
+function packlist(args){
+	if(args.length < 1){
+		throw new Error("$packlist placeholder should have at least 1 arguments!");
+	}
+	var arrType = args[0];
+	if(args.length == 1){
+		var arr = Array();
+		if(typeof arrType !== "string"){
+			throw new Error("Unknown Type '"+arrType+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+		}
+		if(arrType.toLowerCase() !== "string" && arrType.toLowerCase() !== "int"&& arrType.toLowerCase() !== "double") {
+			throw new Error("Unknown Type '"+arrType+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+		}else {	
+			if(arrType.toLowerCase() == "string") {
+				return Java.to(arr,"java.lang.String[]");
+			}
+			if(arrType.toLowerCase() == "int") {
+				return Java.to(arr,"int[]");
+			}
+			if(arrType.toLowerCase() == "double") {
+				return Java.to(arr,"java.lang.Double[]");
+			}	
+		}
+	}
+	if(args.length == 2){
+		var arr = Array()
+		arr.push(args[1]);
+	}
+	if(args.length > 2){
+		var arr = Array.apply(0, Array(args.length - 1));
+		for(i=1; i <= args.length - 1; i++) {
+			arr[i-1] = args[i];
+		}
+	}
+	if(arrType.toLowerCase() !== "string" && arrType.toLowerCase() !== "int"&& arrType.toLowerCase() !== "double") {
+		throw new Error("Unknown Type '"+args[0]+"' ! You can use either 'String', or 'Int', or 'Double' ! [invalid type]");
+	}else {	
+		if(arrType.toLowerCase() == "string") {
+			var arrsType = "string";
+			var arrType = "java.lang.String";
+			var msgType = "String"
+		}
+		if(arrType.toLowerCase() == "int") {
+			var arrsType = "number";
+			var arrType = "java.lang.Integer";
+			var checkDouble = true;
+			var msgType = "Integer";
+		}
+		if(arrType.toLowerCase() == "double") {
+			var arrsType = "number";
+			var arrType = "java.lang.Double";
+			var checkInt = true;
+			var msgType = "Double";
+		}
+		for(i=0; i <= arr.length - 1; i++){
+			if(typeof arr[i] !== arrsType) {
+				throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+			}
+			if(checkDouble == true) {
+				if(isDouble(arr[i]) == true) {
+					throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+				}
+			}
+			if(checkInt == true) {
+				if(isDouble(arr[i]) !== true) {
+					throw new Error("Type of '"+arr[i]+"' is not "+msgType+"! Error occured argument index is "+i+".")
+				}
+			}
+		}
+		return Java.to(arr, arrType+"[]")
+	}
 }


### PR DESCRIPTION
This placeholder has unlimited argument length, and makes an arry with it's arguments, except for argument index 0.
You can also make empty array or size:1 array with this version.

Usage:

    $packlist:"":value[1]:value,[2]:value[3]:.........:value[n]

You can use either "String", or "Int", or "Double".
You should use matched type on value[n].
As I said, this placeholder has unlimited argument length.

For example:
    arr = $packlist:"Int":3:5:2
    #LOG arr[0]
//Result: 3

    arr = $packlist:"hello":"a":"b"
//Result: Error: Unknown Type 'hello' !

    arr = $packlist:"string":"he":3
//Result: Error: Type of '3' is not String! Error occured argument index is 1.

    arr = $packlist:"Double":46:3.5
//Result: Error: Type of '46' is not Double! Error occured argument index is 0.

    arr = $packlist:"Double":12:4.0
    #LOG arr[1]
//Result: 4
//If there is only zero(0) after the decimal point, it will be converted into an integer.
//So $packlist:"Double":1.0 does not work, unfortunately.