### PR TITLE
Compiled for 1.16.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 .idea
 *.iml
 */.settings
+/core/out/production/classes/META-INF/

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     
     ext {
         id = 'TriggerReactor'
-        version = '3.0.4'
+        version = '3.0.5'
         description = 'Simple script parser with infinite possibility'
         author = 'wysohn'
         authors = [

--- a/bukkit/latest/build.gradle
+++ b/bukkit/latest/build.gradle
@@ -12,16 +12,16 @@ import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
 
 task writePluginYml {
-    DumperOptions options = new DumperOptions();
-    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-    options.setPrettyFlow(true);
+    DumperOptions options = new DumperOptions()
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK)
+    options.setPrettyFlow(true)
 
-    File file = new File("$projectDir/src/main/resources/plugin.yml");
+    File file = new File("$projectDir/src/main/resources/plugin.yml")
 
-    InputStream input = new FileInputStream(file);
-    Yaml yaml = new Yaml(options);
-    Map<String, Object> map = yaml.load(input);
-    input.close();
+    InputStream input = new FileInputStream(file)
+    Yaml yaml = new Yaml(options)
+    Map<String, Object> map = yaml.load(input)
+    input.close()
 
     String id = project.ext.id
     String desc = project.ext.description
@@ -60,11 +60,11 @@ task writePluginYml {
     })
     map.put("api-version", 1.13)
 
-    FileWriter writer = new FileWriter(file);
+    FileWriter writer = new FileWriter(file)
     yaml.dump(map, writer)
-    writer.close();
+    writer.close()
 }
 
 dependencies {
-    compile 'org.spigotmc:spigot-api:1.15-R0.1-SNAPSHOT'
+    compile 'org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT'
 }

--- a/bukkit/latest/src/main/resources/plugin.yml
+++ b/bukkit/latest/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TriggerReactor
 main: io.github.wysohn.triggerreactor.bukkit.main.TriggerReactor
-version: 3.0.2
+version: 3.0.5
 author: wysohn
 authors:
 - soliddanii

--- a/bukkit/legacy/src/main/resources/plugin.yml
+++ b/bukkit/legacy/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TriggerReactor
 main: io.github.wysohn.triggerreactor.bukkit.main.TriggerReactor
-version: 3.0.2
+version: 3.0.5
 author: wysohn
 authors:
 - soliddanii


### PR DESCRIPTION
No specific changes required. Tested in 1.16.1 Spigot.
It seems like there were no major changes in API

nothing has changed for bukkit-legacy and sponge