### PR TITLE
New model for CommandTrigger Tab-Completion.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
                 'Alex4386',
                 'RedLime',
                 'mrandriyg',
-                'professer_snape',
+                'Dr_Romantic',
                 'gerzytet',
                 'Kuiprux',
                 'Ioloolo',

--- a/bukkit/latest/src/main/resources/plugin.yml
+++ b/bukkit/latest/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TriggerReactor
 main: io.github.wysohn.triggerreactor.bukkit.main.TriggerReactor
-version: 3.2.2
+version: unspecified
 author: wysohn
 authors:
 - soliddanii
@@ -11,10 +11,11 @@ authors:
 - Alex4386
 - RedLime
 - mrandriyg
-- professer_snape
+- Dr_Romantic
 - gerzytet
 - Kuiprux
 - Ioloolo
+- Sayakie
 softdepend:
 - Vault
 - PlaceholderAPI

--- a/bukkit/legacy/src/main/resources/plugin.yml
+++ b/bukkit/legacy/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TriggerReactor
 main: io.github.wysohn.triggerreactor.bukkit.main.TriggerReactor
-version: 3.2.2
+version: unspecified
 author: wysohn
 authors:
 - soliddanii
@@ -11,10 +11,11 @@ authors:
 - Alex4386
 - RedLime
 - mrandriyg
-- professer_snape
+- Dr_Romantic
 - gerzytet
 - Kuiprux
 - Ioloolo
+- Sayakie
 softdepend:
 - Vault
 - PlaceholderAPI

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
@@ -72,7 +72,6 @@ public class BukkitTabCompleterImpl implements TabCompleter {
                     finalProvideList.addAll(finalCompleter.getCandidates(partial));
                 }
             }
-            //TODO - handle Tab Completer
         }
 
         return finalProvideList;

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
@@ -61,7 +61,7 @@ public class BukkitTabCompleterImpl implements TabCompleter {
 
                 } else { // provide candidates
                     finalProvideList.addAll(values.stream()
-                            .filter(val -> val.startsWith(partial))
+                            .filter(val -> val.toLowerCase().startsWith(partial.toLowerCase()))
                             .collect(Collectors.toList()));
                 }
             }else{

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/BukkitTabCompleterImpl.java
@@ -1,0 +1,94 @@
+package io.github.wysohn.triggerreactor.bukkit.manager.trigger;
+
+import io.github.wysohn.triggerreactor.core.manager.trigger.command.CommandTrigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.command.ITabCompleter;
+import io.github.wysohn.triggerreactor.core.manager.trigger.command.TabCompleterPreDefinedValue;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class BukkitTabCompleterImpl implements TabCompleter {
+    CommandTrigger trigger;
+
+    public BukkitTabCompleterImpl(CommandTrigger trg){
+        this.trigger = trg;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command12, String alias, String[] args) {
+        Map<Integer, Set<ITabCompleter>> tabCompleterMap = trigger.getTabCompleterMap();
+        if(tabCompleterMap == null
+                || tabCompleterMap.get(args.length - 1) == null
+                || tabCompleterMap.get(args.length - 1).size() == 0){
+            return new ArrayList<>();
+        }
+        Set<ITabCompleter> finalCompleters = new HashSet<>();
+        List<String> finalProvideList = new ArrayList<>();
+
+        ConditionTabCompleterIterator:
+        for(ITabCompleter tc : tabCompleterMap.get(args.length - 1)){
+            if(tc.hasConditionMap()){
+
+                ArgumentIterator:
+                for(int i = 0; i < args.length; i++){
+                    if(!tc.hasCondition(i))
+                        continue ArgumentIterator;
+
+                    Pattern pt = tc.getCondition(i);
+                    if(!pt.matcher(args[i]).matches()){
+                        continue ConditionTabCompleterIterator;
+                    }
+                }
+            }
+            finalCompleters.add(tc);
+        }
+
+        FinalTabCompletionIterator:
+        for(ITabCompleter finalCompleter : finalCompleters){
+            if(finalCompleter.isPreDefinedValue()){
+                List<String> values = handlePreDefined(finalCompleter.getPreDefinedValue());
+                String partial = args[args.length - 1];
+                if (partial.length() < 1) { // provide hint
+                    if(finalCompleter.getHint() == null)
+                        finalProvideList.addAll(values);
+                    else
+                        finalProvideList.addAll(finalCompleter.getHint());
+
+                } else { // provide candidates
+                    finalProvideList.addAll(values.stream()
+                            .filter(val -> val.startsWith(partial))
+                            .collect(Collectors.toList()));
+                }
+            }else{
+                String partial = args[args.length - 1];
+                if (partial.length() < 1) { // show hint if nothing is entered yet
+                    finalProvideList.addAll(finalCompleter.getHint());
+                } else {
+                    finalProvideList.addAll(finalCompleter.getCandidates(partial));
+                }
+            }
+            //TODO - handle Tab Completer
+        }
+
+        return finalProvideList;
+    }
+
+    private static List<String> handlePreDefined(TabCompleterPreDefinedValue val){
+        List<String> returning = new ArrayList<>();
+        switch (val){
+            case PLAYERS:
+                Bukkit.getOnlinePlayers().forEach((p) -> {
+                    returning.add(p.getName());
+                });
+                break;
+
+        }
+
+        return returning;
+    }
+}

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/CommandTriggerManager.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/manager/trigger/CommandTriggerManager.java
@@ -21,18 +21,20 @@ import io.github.wysohn.triggerreactor.core.main.TriggerReactorCore;
 import io.github.wysohn.triggerreactor.core.manager.trigger.command.AbstractCommandTriggerManager;
 import io.github.wysohn.triggerreactor.core.manager.trigger.command.CommandTrigger;
 import io.github.wysohn.triggerreactor.core.manager.trigger.command.ITabCompleter;
+import io.github.wysohn.triggerreactor.core.manager.trigger.command.TabCompleterPreDefinedValue;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class CommandTriggerManager extends AbstractCommandTriggerManager implements BukkitTriggerManager {
@@ -54,19 +56,7 @@ public class CommandTriggerManager extends AbstractCommandTriggerManager impleme
         PluginCommand command = createCommand(plugin, triggerName);
         command.setAliases(Arrays.stream(trigger.getAliases())
                 .collect(Collectors.toList()));
-        command.setTabCompleter((sender, command12, alias, args) -> {
-            ITabCompleter tabCompleter = Optional.ofNullable(trigger.getTabCompleters())
-                    .filter(iTabCompleters -> iTabCompleters.length >= args.length)
-                    .map(iTabCompleters -> iTabCompleters[args.length - 1])
-                    .orElse(ITabCompleter.Builder.of().build());
-
-            String partial = args[args.length - 1];
-            if (partial.length() < 1) { // show hint if nothing is entered yet
-                return tabCompleter.getHint();
-            } else {
-                return tabCompleter.getCandidates(partial);
-            }
-        });
+        command.setTabCompleter(new BukkitTabCompleterImpl(trigger));
         command.setExecutor((sender, command1, label, args) -> {
             if (!(sender instanceof Player)) {
                 sender.sendMessage("CommandTrigger works only for Players.");

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactorCore.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/main/TriggerReactorCore.java
@@ -640,6 +640,7 @@ public abstract class TriggerReactorCore implements TaskSupervisor {
                         getCmdManager().reregisterCommand(args[1]);
                     } else if (args.length > 2 && getCmdManager().has(args[1])
                             && (args[2].equals("tab") || args[2].equals("settab"))) {
+                        //TODO - New Command handling logic for new Tab-Completion model.
                         TriggerInfo info = Optional.of(getCmdManager())
                                 .map(man -> man.get(args[1]))
                                 .map(Trigger::getInfo)

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
@@ -85,7 +85,7 @@ public abstract class AbstractCommandTriggerManager extends AbstractTriggerManag
                     }
                 }
                 if(conditions != null){
-                    builder = builder.setConditions(toTabCompleterConditionMap(conditions));
+                    builder = builder.setConditionMap(toTabCompleterConditionMap(conditions));
                 }
                 return builder.build();
             }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/AbstractCommandTriggerManager.java
@@ -60,7 +60,7 @@ public abstract class AbstractCommandTriggerManager extends AbstractTriggerManag
             private ITabCompleter toTabCompleter(Map<String, Object> tabs) {
                 String hint = (String) tabs.get(HINT);
                 String candidates_str = (String) tabs.get(CANDIDATES);
-                List<Map<String, Object>> conditions = tabs.get(CONDITIONS) == null ? (List<Map<String, Object>>) tabs.get(CONDITIONS) : null;
+                List<Map<String, Object>> conditions = tabs.get(CONDITIONS) != null ? (List<Map<String, Object>>) tabs.get(CONDITIONS) : null;
 
                 ITabCompleter.Builder builder;
 
@@ -81,11 +81,11 @@ public abstract class AbstractCommandTriggerManager extends AbstractTriggerManag
                         if (hint == null)
                             builder = ITabCompleter.Builder.of().setHint(ITabCompleter.list(candidates_str.split(","))).setCandidate(ITabCompleter.list(candidates_str.split(",")));
                         else
-                            builder = ITabCompleter.Builder.of(Template.PLAYER).setHint(ITabCompleter.list(hint.split(","))).setCandidate(ITabCompleter.list(candidates_str.split(",")));
+                            builder = ITabCompleter.Builder.of().setHint(ITabCompleter.list(hint.split(","))).setCandidate(ITabCompleter.list(candidates_str.split(",")));
                     }
                 }
                 if(conditions != null){
-                    builder = builder.setCondtions(toTabCompleterConditionMap(conditions));
+                    builder = builder.setConditions(toTabCompleterConditionMap(conditions));
                 }
                 return builder.build();
             }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTrigger.java
@@ -4,12 +4,12 @@ import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManag
 import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
 import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
 
-import java.util.Arrays;
+import java.util.*;
 
 public class CommandTrigger extends Trigger {
     String[] permissions = new String[0];
     String[] aliases = new String[0];
-    ITabCompleter[] tabCompleters = new ITabCompleter[0];
+    Map<Integer, Set<ITabCompleter>> tabCompleterMap = new HashMap<>();
 
     public CommandTrigger(TriggerInfo info, String script) throws AbstractTriggerManager.TriggerInitFailedException {
         super(info, script);
@@ -41,17 +41,19 @@ public class CommandTrigger extends Trigger {
         }
     }
 
-    public ITabCompleter[] getTabCompleters() {
-        return tabCompleters;
+    public Map<Integer, Set<ITabCompleter>> getTabCompleterMap() {
+        return tabCompleterMap;
     }
 
-    public void setTabCompleters(ITabCompleter[] tabCompleters) {
-        if (tabCompleters == null) {
-            this.tabCompleters = new ITabCompleter[0];
+    public void setTabCompleterMap(Map<Integer, Set<ITabCompleter>> tabCompleterMap) {
+        if (tabCompleterMap == null) {
+            this.tabCompleterMap = new HashMap<>();
         } else {
-            this.tabCompleters = tabCompleters;
+            this.tabCompleterMap = tabCompleterMap;
         }
     }
+
+
 
     @Override
     public CommandTrigger clone() {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
@@ -4,6 +4,7 @@ package io.github.wysohn.triggerreactor.core.manager.trigger.command;
 
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 /**
@@ -195,7 +196,7 @@ public interface ITabCompleter {
             return this;
         }
 
-        public Builder setConditions(Map<Integer, Pattern> conditionMap){
+        public Builder setConditionMap(Map<Integer, Pattern> conditionMap){
             this.conditions = conditionMap;
 
             return this;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
@@ -100,7 +100,7 @@ public interface ITabCompleter {
 
         List<String> hint,candidate;
         TabCompleterPreDefinedValue preDefinedValue;
-        Map<Integer, Pattern> condtions;
+        Map<Integer, Pattern> conditions;
 
         private Builder(){
             this.hint = new ArrayList<>();
@@ -190,71 +190,20 @@ public interface ITabCompleter {
             this.hint = new ArrayList<>();
             this.candidate = new ArrayList<>();
             this.preDefinedValue = null;
-            this.condtions = null;
+            this.conditions = null;
 
             return this;
         }
 
-        public Builder setCondtions(Map<Integer, Pattern> conditionMap){
-            this.condtions = conditionMap;
+        public Builder setConditions(Map<Integer, Pattern> conditionMap){
+            this.conditions = conditionMap;
 
             return this;
         }
 
 
         public ITabCompleter build(){
-            return new ITabCompleter() {
-                @Override
-                public List<String> getCandidates(String part) {
-                    if(preDefinedValue != null || candidate == null){
-                        return null;
-                    }else {
-                        return candidate.stream()
-                                .filter(val -> val.startsWith(part))
-                                .collect(Collectors.toList());
-                    }
-                }
-                @Override
-                public List<String> getHint() {
-                    return hint;
-                }
-
-                @Override
-                public boolean isPreDefinedValue() {
-                    return preDefinedValue != null;
-                }
-
-                @Override
-                public TabCompleterPreDefinedValue getPreDefinedValue() {
-                    return preDefinedValue;
-                }
-
-                @Override
-                public boolean hasConditionMap() {
-                    return condtions == null || condtions.size() == 0;
-                }
-
-                @Override
-                public Map<Integer, Pattern> getConditionMap() {
-                    return condtions;
-                }
-
-                @Override
-                public boolean hasCondition(Integer index) {
-                    if(!hasConditionMap())
-                        return false;
-                    else
-                        return condtions.get(index) == null;
-                }
-
-                @Override
-                public Pattern getCondition(Integer index) {
-                    if(!hasConditionMap())
-                        return null;
-                    else
-                        return condtions.get(index);
-                }
-            };
+            return new ITabCompleterImpl(this);
 
         }
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleter.java
@@ -159,6 +159,21 @@ public interface ITabCompleter {
 
             return this;
         }
+        public Builder setCondition(int index, String regex) throws PatternSyntaxException{
+            Pattern ptn = Pattern.compile(regex);
+            if(this.conditions== null){
+                this.conditions = new HashMap<Integer, Pattern>();
+            }
+            this.conditions.put(index, ptn);
+            return this;
+        }
+        public Builder setCondition(int index, Pattern pattern) throws PatternSyntaxException{
+            if(this.conditions== null){
+                this.conditions = new HashMap<Integer, Pattern>();
+            }
+            this.conditions.put(index, pattern);
+            return this;
+        }
         public Builder setHint(String...hints){
             this.hint = list(hints);
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleterImpl.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/ITabCompleterImpl.java
@@ -1,0 +1,72 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.command;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class ITabCompleterImpl implements ITabCompleter{
+        List<String> hint;
+        List<String> candidate;
+        TabCompleterPreDefinedValue preDefinedValue;
+        Map<Integer, Pattern> conditions;
+
+        protected ITabCompleterImpl(ITabCompleter.Builder builder){
+            hint = builder.hint;
+            candidate = builder.candidate;
+            preDefinedValue = builder.preDefinedValue;
+            conditions = builder.conditions;
+        }
+
+        @Override
+        public List<String> getCandidates(String part) {
+            if(preDefinedValue != null || candidate == null){
+                return null;
+            }else {
+                return candidate.stream()
+                        .filter(val -> val.toLowerCase().startsWith(part.toLowerCase()))
+                        .collect(Collectors.toList());
+            }
+        }
+        @Override
+        public List<String> getHint() {
+            return hint;
+        }
+
+        @Override
+        public boolean isPreDefinedValue() {
+            return preDefinedValue != null;
+        }
+
+        @Override
+        public TabCompleterPreDefinedValue getPreDefinedValue() {
+            return preDefinedValue;
+        }
+
+        @Override
+        public boolean hasConditionMap() {
+            return conditions != null && conditions.size() != 0;
+        }
+
+        @Override
+        public Map<Integer, Pattern> getConditionMap() {
+            return conditions;
+        }
+
+        @Override
+        public boolean hasCondition(Integer index) {
+            if(!hasConditionMap())
+                return false;
+            else
+                return conditions.get(index) != null;
+        }
+
+        @Override
+        public Pattern getCondition(Integer index) {
+            if(!hasConditionMap())
+                return null;
+            else
+                return conditions.get(index);
+        }
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/TabCompleterPreDefinedValue.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/TabCompleterPreDefinedValue.java
@@ -1,0 +1,5 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.command;
+
+public enum TabCompleterPreDefinedValue {
+    PLAYERS
+}


### PR DESCRIPTION
<h1> New Command Trigger Tab-Completion Model Suggestion  </h1>

<h2> Command Usage </h2>

**NOT YET IMPLEMENTED**


<h2> JSON </h2>

Tested and Fully functional on
- [x] Bukkit-latest
- [ ] Bukkit-legacy
- [ ] Sponge

Example JSON:
```json
{
  "tabs": [
    {
		"index":0,
		"candidates": "give,get,astro"
    },
	{
		"index":1,
		"candidates": "$playerlist",
		"conditions": [
			{
				"index": 0,
				"regex": "give|get"
			}
		]
	},
	{
		"index":1,
		"hint": "<amount>",
		"conditions": [
			{
				"index": 0,
				"regex": "astro"
			}
		]
	},
	{
		"index":2,
		"hint": "<amount>",
		"conditions": [
			{
				"index": 0,
				"regex": "give|get"
			}
		]
	},
	{
		"index":2,
		"hint":"<another>",
		"candidates": "aaaa,bbbb,cccc",
		"conditions": [
			{
				"index": 0,
				"regex": "astro"
			},
			{
				"index": 1,
				"regex": "100"
			}		
		]
	}	
  ],
  "aliases": [],
  "permissions": []
}
```

<h3> INDEX </h3>
As you can see, you can now specify INDEX of each tab-completer. Still, if "index" is missed, the order(index) of the object in list would be the "index" value like before. Also, you may add more than one tab-completer for one index, so that you can implement different hint/candidate based on "conditions". 

---
<h3> CONDITIONS </h3>
A new feature.  You can now test specific String args[index]  with regex.
<h4> INDEX in CONDITION</h4>
The index of arguments that should be tested.

<h4> REGEX in CONDITION</h4>
The regex string that should be used for test.

So, in conclusion, the CONDTION acts like
```java
matches(args[INDEX], REGEX)
```

And also, as you can see on example , you can add multiple CONDITION at one tab-completer, so that checking multiple arguments would be available (they treated as AND expression).