### PR TITLE
refactor: Empower script lexer, parser, interpreter to write with confidence in a wider variety of domains

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/wrapper/Accessor.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/wrapper/Accessor.java
@@ -52,6 +52,13 @@ public class Accessor {
                 throw new IllegalArgumentException(target.getClass() + " is not a valid type for array operation.");
             }
         } else if (targetParent instanceof Class) {
+            Class<?>[] nestedClasses = ((Class<?>) targetParent).getClasses();
+            if (nestedClasses.length > 0) {
+                for (Class<?> nestedClass : nestedClasses) {
+                    if (nestedClass.toString().endsWith((String) target)) return nestedClass;
+                }
+            }
+
             return ReflectionUtil.getField((Class<?>) targetParent, (Object) null, (String) target);
         } else {
             return ReflectionUtil.getField(targetParent, (String) target);

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -349,7 +349,7 @@ public class TestLexer {
     }
 
     @Test
-    public void testComment() throws Exception {
+    public void testLineComment() throws Exception {
         Charset charset = StandardCharsets.UTF_8;
         String text;
         Lexer lexer;
@@ -364,21 +364,63 @@ public class TestLexer {
         lexer = new Lexer(text, charset);
         testToken(lexer, Type.INTEGER, "1");
         testEnd(lexer);
+    }
 
-        text = "2/*hey*/+3";
+    @Test
+    public void testBlockComment() throws Exception {
+        Charset charset = StandardCharsets.UTF_8;
+        String text;
+        Lexer lexer;
+
+        text = "1/**/+2";
         lexer = new Lexer(text, charset);
-        testToken(lexer, Type.INTEGER, "2");
+        testToken(lexer, Type.INTEGER, "1");
         testToken(lexer, Type.OPERATOR_A, "+");
-        testToken(lexer, Type.INTEGER, "3");
+        testToken(lexer, Type.INTEGER, "2");
         testEnd(lexer);
 
-        text = "4/**\n"
-            + " * heya" +
-            " */+5";
+        text = "3/*heya*/+4";
         lexer = new Lexer(text, charset);
-        testToken(lexer, Type.INTEGER, "4");
+        testToken(lexer, Type.INTEGER, "3");
         testToken(lexer, Type.OPERATOR_A, "+");
+        testToken(lexer, Type.INTEGER, "4");
+        testEnd(lexer);
+
+        text = "5*/**\n"
+            + " * heya" +
+            " **/6";
+        lexer = new Lexer(text, charset);
         testToken(lexer, Type.INTEGER, "5");
+        testToken(lexer, Type.OPERATOR_A, "*");
+        testToken(lexer, Type.INTEGER, "6");
+        testEnd(lexer);
+
+        text = "7/* /* */ /* */ */";
+        lexer = new Lexer(text, charset);
+        testToken(lexer, Type.INTEGER, "7");
+        testEnd(lexer);
+    }
+
+    @Test(expected = LexerException.class)
+    public void testBlockCommentException() throws IOException, LexerException {
+        Charset charset = StandardCharsets.UTF_8;
+        String text;
+        Lexer lexer;
+
+        text = "1/**+2";
+        lexer = new Lexer(text, charset);
+        testToken(lexer, Type.INTEGER, "1");
+        testEnd(lexer);
+    }
+
+    @Test(expected = LexerException.class)
+    public void testBlockCommentException2() throws IOException, LexerException {
+        Charset charset = StandardCharsets.UTF_8;
+        String text;
+        Lexer lexer;
+
+        text = "/* /* /* */ /* */ */";
+        lexer = new Lexer(text, charset);
         testEnd(lexer);
     }
 


### PR DESCRIPTION
## 🚀 Features

*  Lexer now has two useful methods: `#first()` and `#second()` that do not consume next or second symbol.
*  Nested block comments should be parsed appropriately.
    *  `/* /* */ */`: Works without any lexer exception
    *  `/* /* */ /* */`: Works without any lexer exception
    *  `/* /* */`: Throws lexer exception. Missing 1 closing block comment
    *  `/* `: Throws lexer exception. No closing block comment
*  Introduce accessing nested classes (*Limited implementation*).

## 🐛 Bug Fixes

*  Block comments without any content(`/****/`) could not be lexed.

## 🪞 Styling

*  Update lexer javadocs.
