### PR TITLE
Support exponentiation operator(`**`)

### DIFF
--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/interpreter/Interpreter.java
@@ -998,6 +998,9 @@ public class Interpreter {
                         case "*":
                             result = integer ? left.toInteger() * right.toInteger() : left.toDecimal() * right.toDecimal();
                             break;
+                        case "**":
+                            result = integer ? Math.pow(left.toInteger(), right.toInteger()) : Math.pow(left.toDecimal(), right.toDecimal());
+                            break;
                         case "/":
                             result = integer ? left.toInteger() / right.toInteger() : left.toDecimal() / right.toDecimal();
                             break;

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/lexer/Lexer.java
@@ -413,6 +413,9 @@ public class Lexer {
             } else if (("+".equals(op) || "-".equals(op)) && op.equals(String.valueOf(c))) {
                 read();
                 return new Token(Type.OPERATOR_UNARY, op+op, row, col);
+            } else if (("*".equals(op)) && c == '*') {
+                read();
+                return new Token(Type.OPERATOR_A, op+op, row, col);
             } else {
                 return new Token(Type.OPERATOR_A, op, row, col);
             }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/script/parser/Parser.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/script/parser/Parser.java
@@ -831,7 +831,7 @@ public class Parser {
 
     private Node parseFactorAndTerm(Node left) throws IOException, LexerException, ParserException {
         if (token != null && token.type == Type.OPERATOR_A
-                && ("*".equals(token.value) || "/".equals(token.value) || "%".equals(token.value))) {
+                && ("*".equals(token.value) || "**".equals(token.value) || "/".equals(token.value) || "%".equals(token.value))) {
             Node node = new Node(token);
             nextToken();
 

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/interpreter/TestInterpreter.java
@@ -867,6 +867,28 @@ public class TestInterpreter {
     }
 
     @Test
+    public void testExponentiationOperator() throws IOException, LexerException, ParserException, InterpreterException {
+        Charset charset = StandardCharsets.UTF_8;
+        String text = "a = 2 ** 2";
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+        Map<String, Executor> executorMap = new HashMap<>();
+
+        Interpreter interpreter = new Interpreter(root);
+        interpreter.setExecutorMap(executorMap);
+        interpreter.setTaskSupervisor(mockTask);
+        interpreter.setSelfReference(new CommonFunctions());
+
+        interpreter.startWithContext(null);
+
+        Object a = interpreter.getVars().get("a");
+        assertEquals(a, 4);
+    }
+
+    @Test
     public void testShortCircuit() throws Exception {
         Charset charset = StandardCharsets.UTF_8;
         String text = ""

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/lexer/TestLexer.java
@@ -282,6 +282,38 @@ public class TestLexer {
     }
 
     @Test
+    public void testExponentiationOperator() throws IOException, LexerException {
+        String text;
+        Lexer lexer;
+
+        {
+            text = "a = 2 ** 2";
+            lexer = new Lexer(text, charset);
+
+            testToken(lexer, Type.ID, "a");
+            testToken(lexer, Type.OPERATOR, "=");
+            testToken(lexer, Type.INTEGER, "2");
+            testToken(lexer, Type.OPERATOR_A, "**");
+            testToken(lexer, Type.INTEGER, "2");
+            testEnd(lexer);
+        }
+        {
+            /// Note(Sayakie): It is _INVALID_ expression, but it should be handled by the Parser.
+            /// We just care about spaces are allowed in the exponentiation operator.
+            text = "a = 2 * * 2";
+            lexer = new Lexer(text, charset);
+
+            testToken(lexer, Type.ID, "a");
+            testToken(lexer, Type.OPERATOR, "=");
+            testToken(lexer, Type.INTEGER, "2");
+            testToken(lexer, Type.OPERATOR_A, "*");
+            testToken(lexer, Type.OPERATOR_A, "*");
+            testToken(lexer, Type.INTEGER, "2");
+            testEnd(lexer);
+        }
+    }
+
+    @Test
     public void testSemicolon() throws Exception {
         String text = "#MESSAGE !true;#MESSAGE \"next\"";
 

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestParser {
 
@@ -263,6 +264,7 @@ public class TestParser {
         assertEquals(new Node(new Token(Type.OPERATOR_A, "**")), queue.poll());
         assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
+        assertTrue(queue.isEmpty());
     }
 
     @Test

--- a/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
+++ b/core/src/test/java/io/github/wysohn/triggerreactor/core/script/parser/TestParser.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertEquals;
 
 public class TestParser {
 
+    private static final Charset charset = StandardCharsets.UTF_8;
+
     @Test
     public void testParse() throws IOException, LexerException, ParserException {
         Charset charset = Charset.forName("UTF-8");
@@ -239,6 +241,28 @@ public class TestParser {
 
         assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
         assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void testExponentiationOperator() throws IOException, LexerException, ParserException {
+        String text = "a = 2 ** 2";
+
+        Lexer lexer = new Lexer(text, charset);
+        Parser parser = new Parser(lexer);
+
+        Node root = parser.parse();
+        Queue<Node> queue = new LinkedList<>();
+
+        serializeNode(queue, root);
+
+        assertEquals(new Node(new Token(Type.THIS, "<This>")), queue.poll());
+        assertEquals(new Node(new Token(Type.ID, "a")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, ".")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "2")), queue.poll());
+        assertEquals(new Node(new Token(Type.INTEGER, "2")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR_A, "**")), queue.poll());
+        assertEquals(new Node(new Token(Type.OPERATOR, "=")), queue.poll());
+        assertEquals(new Node(new Token(Type.ROOT, "<ROOT>")), queue.poll());
     }
 
     @Test


### PR DESCRIPTION
# Exponentiation Operator
The exponentiation operator (`**`) raises the first operand to the power of the second operand. It is equivalent to [Math#pow(double, double)](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Math.html#pow(double,double)). For example, `x ** y` produces the same result as `Math.pow(x, y)`, except it dynamically bounds to integer type if two arguments are also integer types.

## Syntax
```java
x ** y
```

## Examples
```java
#MESSAGE 2 ** 3        // Prints "8"
#MESSAGE 3 ** 2        // Prints "9"
#MESSAGE 3 ** 2.5      // Prints "15.588457268119896"
#MESSAGE 10 ** -1      // Prints "0"
#MESSAGE 10 ** -1.0    // Prints "0.1"
#MESSAGE 2 ** 1024     // Prints "2147483647" (same as `Integer.MAX_VALUE`, match to int safely)
#MESSAGE 2 ** 1024.0   // Prints "Infinity" (higher than `Double.MAX_VALUE`)
```

# Exponentiation Assignment
> **Note** that this specification does ***NOT*** implemented yet.

The exponentiation assignment operator (`**=`) raises the value of a variable to the power of the right operand.

## Syntax
```java
x = 5
x **= 2

// Equivalent to "x = 5 ** 2"
```