### PR TITLE
Expose the executing trigger instance

### DIFF
--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/BukkitPluginManagement.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/BukkitPluginManagement.java
@@ -186,6 +186,10 @@ public class BukkitPluginManagement implements IPluginManagement {
 
                             if (sync) {
                                 trigger.activate(context.getTriggerCause(), context.getVars(), true);
+
+                                // reset the variable space to synchronize the variable space
+                                context.clearVars();
+                                context.putAllVars(trigger.getVarCopy());
                             } else {//use snapshot to avoid concurrent modification
                                 trigger.activate(context.getTriggerCause(), new HashMap<>(context.getVars()), false);
                             }

--- a/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/BukkitTaskSupervisor.java
+++ b/bukkit/src/main/java/io/github/wysohn/triggerreactor/bukkit/main/BukkitTaskSupervisor.java
@@ -107,6 +107,11 @@ public class BukkitTaskSupervisor implements TaskSupervisor {
 
     @Override
     public <T> Future<T> submitSync(Callable<T> call) {
+        if (!plugin.isEnabled()) {
+            throw new IllegalStateException("Plugin is not enabled. If you see this error while" +
+                    " the server is shutting down, you can simply ignore this.");
+        }
+
         if (this.isServerThread()) {
             return immediateFuture(call);
         } else {

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
@@ -185,6 +185,7 @@ public abstract class Trigger implements Cloneable, IObservable {
             return false;
         }
 
+        scriptVars.put("this", this);
         scriptVars.put("event", e);
         scriptVars.putAll(triggerDependencyFacade.getExtraVariables(e));
 

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/Trigger.java
@@ -185,7 +185,7 @@ public abstract class Trigger implements Cloneable, IObservable {
             return false;
         }
 
-        scriptVars.put("this", this);
+        scriptVars.put("this", getTriggerFacade());
         scriptVars.put("event", e);
         scriptVars.putAll(triggerDependencyFacade.getExtraVariables(e));
 
@@ -331,6 +331,10 @@ public abstract class Trigger implements Cloneable, IObservable {
      */
     public void setIgnoreSyncIfNotServerThread(boolean ignoreSyncIfNotServerThread) {
         this.ignoreSyncIfNotServerThread = ignoreSyncIfNotServerThread;
+    }
+
+    public TriggerFacade getTriggerFacade() {
+        return new TriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/TriggerFacade.java
@@ -1,0 +1,33 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger;
+
+import java.util.Map;
+
+public class TriggerFacade {
+
+    protected final Trigger trigger;
+
+    public TriggerFacade(Trigger trigger) {
+        this.trigger = trigger;
+    }
+
+    public TriggerInfo getInfo() {
+        return trigger.getInfo();
+    }
+
+    public String getScript() {
+        return trigger.getScript();
+    }
+
+    public synchronized Map<String, Object> getVarCopy() {
+        return trigger.getVarCopy();
+    }
+
+    public Trigger triggerCopy() {
+        return trigger.clone();
+    }
+
+    @Override
+    public String toString() {
+        return trigger.toString();
+    }
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AreaTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AreaTrigger.java
@@ -23,6 +23,7 @@ import io.github.wysohn.triggerreactor.core.manager.annotation.TriggerRuntimeDep
 import io.github.wysohn.triggerreactor.core.manager.location.Area;
 import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
 import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
 import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
 import io.github.wysohn.triggerreactor.core.script.interpreter.Interpreter;
 import io.github.wysohn.triggerreactor.tools.StringUtils;
@@ -96,6 +97,11 @@ public class AreaTrigger extends Trigger {
             default:
                 throw new RuntimeException("Unknown area event type " + type);
         }
+    }
+
+    @Override
+    public AreaTriggerFacade getTriggerFacade() {
+        return new AreaTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AreaTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/area/AreaTriggerFacade.java
@@ -1,0 +1,40 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.area;
+
+import io.github.wysohn.triggerreactor.core.bridge.entity.IEntity;
+import io.github.wysohn.triggerreactor.core.manager.location.Area;
+import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+import java.util.List;
+import java.util.UUID;
+
+public class AreaTriggerFacade extends TriggerFacade {
+    public AreaTriggerFacade(AreaTrigger trigger) {
+        super(trigger);
+    }
+
+    public Area getArea() {
+        return ((AreaTrigger) trigger).getArea();
+    }
+
+    public TriggerFacade getEnterTrigger() {
+        return ((AreaTrigger) trigger).getEnterTrigger().getTriggerFacade();
+    }
+
+    public TriggerFacade getExitTrigger() {
+        return ((AreaTrigger) trigger).getExitTrigger().getTriggerFacade();
+    }
+
+    public IEntity getEntity(UUID uuid) {
+        return ((AreaTrigger) trigger).getEntity(uuid);
+    }
+
+    public IEntity getEntity(String uuid) {
+        return getEntity(UUID.fromString(uuid));
+    }
+
+    public List<IEntity> getEntities() {
+        return ((AreaTrigger) trigger).getEntities();
+    }
+
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTrigger.java
@@ -20,10 +20,7 @@ package io.github.wysohn.triggerreactor.core.manager.trigger.command;
 import com.google.inject.assistedinject.Assisted;
 import io.github.wysohn.triggerreactor.core.main.command.ICommand;
 import io.github.wysohn.triggerreactor.core.manager.annotation.TriggerRuntimeDependency;
-import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
-import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerConfigKey;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
+import io.github.wysohn.triggerreactor.core.manager.trigger.*;
 
 import javax.inject.Inject;
 import java.util.*;
@@ -94,6 +91,11 @@ public class CommandTrigger extends Trigger {
 
     public void setCommand(ICommand command) {
         this.command = command;
+    }
+
+    @Override
+    public CommandTriggerFacade getTriggerFacade() {
+        return new CommandTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/command/CommandTriggerFacade.java
@@ -1,0 +1,33 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.command;
+
+import io.github.wysohn.triggerreactor.core.main.command.ICommand;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+import java.util.Map;
+import java.util.Set;
+
+public class CommandTriggerFacade extends TriggerFacade {
+    public CommandTriggerFacade(CommandTrigger trigger) {
+        super(trigger);
+    }
+
+    public String[] getPermissions() {
+        return ((CommandTrigger) trigger).getPermissions();
+    }
+
+    public void setPermissions(String[] permissions) {
+        ((CommandTrigger) trigger).setPermissions(permissions);
+    }
+
+    public String[] getAliases() {
+        return ((CommandTrigger) trigger).getAliases();
+    }
+
+    public Map<Integer, Set<ITabCompleter>> getTabCompleterMap() {
+        return ((CommandTrigger) trigger).getTabCompleterMap();
+    }
+
+    public ICommand getCommand() {
+        return ((CommandTrigger) trigger).getCommand();
+    }
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/CustomTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/CustomTrigger.java
@@ -21,6 +21,7 @@ import com.google.inject.assistedinject.Assisted;
 import io.github.wysohn.triggerreactor.core.IEventHook;
 import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
 import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
 import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
 
 import javax.inject.Inject;
@@ -43,6 +44,11 @@ public class CustomTrigger extends Trigger implements IEventHook {
         super(info, script);
         this.event = event;
         this.eventName = eventName;
+    }
+
+    @Override
+    public CustomTriggerFacade getTriggerFacade() {
+        return new CustomTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/CustomTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/custom/CustomTriggerFacade.java
@@ -1,0 +1,18 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.custom;
+
+import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+public class CustomTriggerFacade extends TriggerFacade {
+    public CustomTriggerFacade(CustomTrigger trigger) {
+        super(trigger);
+    }
+
+    public Class<?> getEvent() {
+        return ((CustomTrigger) trigger).getEvent();
+    }
+
+    public String getEventName() {
+        return ((CustomTrigger) trigger).getEventName();
+    }
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/InventoryTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/InventoryTrigger.java
@@ -22,10 +22,7 @@ import com.google.inject.assistedinject.Assisted;
 import io.github.wysohn.triggerreactor.core.bridge.IItemStack;
 import io.github.wysohn.triggerreactor.core.main.IExceptionHandle;
 import io.github.wysohn.triggerreactor.core.main.IPluginManagement;
-import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
-import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerConfigKey;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
+import io.github.wysohn.triggerreactor.core.manager.trigger.*;
 import io.github.wysohn.triggerreactor.core.script.interpreter.interrupt.ProcessInterrupter;
 
 public class InventoryTrigger extends Trigger {
@@ -71,6 +68,11 @@ public class InventoryTrigger extends Trigger {
     @Override
     protected ProcessInterrupter createInterrupter() {
         return pluginManagement.createInterrupterForInv(cooldowns, InventoryTriggerManager.inventoryMap);
+    }
+
+    @Override
+    public InventoryTriggerFacade getTriggerFacade() {
+        return new InventoryTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/InventoryTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/inventory/InventoryTriggerFacade.java
@@ -1,0 +1,25 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.inventory;
+
+import io.github.wysohn.triggerreactor.core.bridge.IItemStack;
+import io.github.wysohn.triggerreactor.core.bridge.entity.IPlayer;
+import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+public class InventoryTriggerFacade extends TriggerFacade {
+    public InventoryTriggerFacade(InventoryTrigger trigger) {
+        super(trigger);
+    }
+
+    public IItemStack[] getItems() {
+        return ((InventoryTrigger) trigger).getItems();
+    }
+
+    public boolean canPickup() {
+        return ((InventoryTrigger) trigger).canPickup();
+    }
+
+    public String getTitle() {
+        return ((InventoryTrigger) trigger).getTitle();
+    }
+
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/ClickTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/ClickTrigger.java
@@ -20,6 +20,7 @@ package io.github.wysohn.triggerreactor.core.manager.trigger.location;
 import com.google.inject.assistedinject.Assisted;
 import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
 import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
 import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
 
 import javax.inject.Inject;
@@ -51,6 +52,11 @@ public class ClickTrigger extends Trigger {
             return true;
 
         return super.activate(e, scriptVars);
+    }
+
+    @Override
+    public LocationTriggerFacade getTriggerFacade() {
+        return new LocationTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/LocationTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/LocationTriggerFacade.java
@@ -1,0 +1,25 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.location;
+
+import io.github.wysohn.triggerreactor.core.manager.location.SimpleLocation;
+import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+public class LocationTriggerFacade extends TriggerFacade {
+    public LocationTriggerFacade(Trigger trigger) {
+        super(trigger);
+    }
+
+    public String getTriggerTypeName() {
+        if (trigger instanceof ClickTrigger) {
+            return "Click";
+        } else if (trigger instanceof WalkTrigger) {
+            return "Walk";
+        } else {
+            return "";
+        }
+    }
+
+    public SimpleLocation getLocation() {
+        return SimpleLocation.valueOf(trigger.getInfo().getTriggerName());
+    }
+}

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/WalkTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/location/WalkTrigger.java
@@ -35,6 +35,11 @@ public class WalkTrigger extends Trigger {
     }
 
     @Override
+    public LocationTriggerFacade getTriggerFacade() {
+        return new LocationTriggerFacade(this);
+    }
+
+    @Override
     public Trigger clone() {
         return factory.create(info, script);
     }

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/RepeatingTrigger.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/RepeatingTrigger.java
@@ -22,10 +22,7 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import io.github.wysohn.triggerreactor.core.main.IExceptionHandle;
 import io.github.wysohn.triggerreactor.core.manager.annotation.TriggerRuntimeDependency;
-import io.github.wysohn.triggerreactor.core.manager.trigger.AbstractTriggerManager;
-import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerConfigKey;
-import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerInfo;
+import io.github.wysohn.triggerreactor.core.manager.trigger.*;
 import io.github.wysohn.triggerreactor.tools.ValidationUtil;
 
 import java.util.HashMap;
@@ -97,6 +94,11 @@ public class RepeatingTrigger extends Trigger implements Runnable {
 
     public void setAutoStart(boolean autoStart) {
         info.put(TriggerConfigKey.KEY_TRIGGER_REPEATING_AUTOSTART, autoStart);
+    }
+
+    @Override
+    public RepeatingTriggerFacade getTriggerFacade() {
+        return new RepeatingTriggerFacade(this);
     }
 
     @Override

--- a/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/RepeatingTriggerFacade.java
+++ b/core/src/main/java/io/github/wysohn/triggerreactor/core/manager/trigger/repeating/RepeatingTriggerFacade.java
@@ -1,0 +1,31 @@
+package io.github.wysohn.triggerreactor.core.manager.trigger.repeating;
+
+import io.github.wysohn.triggerreactor.core.manager.trigger.Trigger;
+import io.github.wysohn.triggerreactor.core.manager.trigger.TriggerFacade;
+
+public class RepeatingTriggerFacade extends TriggerFacade {
+    public RepeatingTriggerFacade(RepeatingTrigger trigger) {
+        super(trigger);
+    }
+
+    public boolean isAutoStart() {
+        return ((RepeatingTrigger) trigger).isAutoStart();
+    }
+
+    public long getInterval() {
+        return ((RepeatingTrigger) trigger).getInterval();
+    }
+
+    public void setInterval(long interval) {
+        ((RepeatingTrigger) trigger).setInterval(interval);
+    }
+
+
+    public boolean isPause() {
+        return ((RepeatingTrigger) trigger).isPaused();
+    }
+
+    public void setPause(boolean pause) {
+        ((RepeatingTrigger) trigger).setPaused(pause);
+    }
+}


### PR DESCRIPTION
this is a little change, user can access trigger object.
It might not be good for security, but its increase users df, i guess

and The above PR may be used for "sync invTrigger vars form previous Task" that we are working on additionally.

`#GUI "invTrigger", true` <- vars sync status

\+ I did PR for now, but where should I add the test case? It's hard because there's no example..